### PR TITLE
Add session support and show turn

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,9 +8,11 @@
         body { margin: 0; font-family: Arial, sans-serif; background: #222; color: #eee; }
         #game { display: block; margin: 40px auto; background: #34495e; }
         #score { position: absolute; top: 10px; right: 20px; font-size: 24px; }
+        #turn { position: absolute; top: 10px; left: 20px; font-size: 24px; }
     </style>
 </head>
 <body>
+    <div id="turn"></div>
     <div id="score">0 - 0</div>
     <canvas id="game" width="820" height="820"></canvas>
     <script src="script.js"></script>

--- a/public/script.js
+++ b/public/script.js
@@ -11,7 +11,16 @@ let winner = null;
 let player = 0;
 
 const wsProto = location.protocol === 'https:' ? 'wss' : 'ws';
-const ws = new WebSocket(`${wsProto}://${location.host}`);
+const params = new URLSearchParams(location.search);
+let room = params.get('room');
+if (!room) {
+    room = Math.random().toString(36).slice(2, 8);
+    params.set('room', room);
+    history.replaceState(null, '', `?${params.toString()}`);
+}
+const ws = new WebSocket(`${wsProto}://${location.host}?room=${room}`);
+
+const turnEl = document.getElementById('turn');
 
 ws.addEventListener('message', (ev) => {
     const msg = JSON.parse(ev.data);
@@ -53,6 +62,11 @@ function draw() {
     }
 
     document.getElementById('score').textContent = `${captured[1]} - ${captured[2]}`;
+    if (winner) {
+        turnEl.textContent = `Winner: Player ${winner}`;
+    } else {
+        turnEl.textContent = current === 1 ? "Black's Turn" : "White's Turn";
+    }
 }
 
 function drawStone(x,y,val){


### PR DESCRIPTION
## Summary
- support multiple sessions by passing `room` id to websocket
- display current player's turn and winner on the page

## Testing
- `node server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_685558fbbfa0832590968cf353417115