### PR TITLE
Add session setup UI and persistent IDs

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -14,6 +14,11 @@
 <body>
     <div id="turn"></div>
     <div id="score">0 - 0</div>
+    <div id="setup" style="text-align:center; margin-top:10px;">
+        <label>Your ID: <input id="uidField" size="8"></label>
+        <label style="margin-left:10px;">Opponent ID: <input id="otherField" size="8"></label>
+        <button id="startBtn">Start Game</button>
+    </div>
     <canvas id="game" width="760" height="760"></canvas>
     <script src="script.js"></script>
 </body>

--- a/public/script.js
+++ b/public/script.js
@@ -10,23 +10,54 @@ let banned = new Set();
 let winner = null;
 let player = 0;
 
+const setupEl = document.getElementById('setup');
+const uidField = document.getElementById('uidField');
+const otherField = document.getElementById('otherField');
+const startBtn = document.getElementById('startBtn');
+
 const wsProto = location.protocol === 'https:' ? 'wss' : 'ws';
 const params = new URLSearchParams(location.search);
+let uid = params.get('uid');
+let other = params.get('other');
+
+if (!uid) {
+    uid = localStorage.getItem('komiId') || Math.random().toString(36).slice(2,8);
+    localStorage.setItem('komiId', uid);
+    params.set('uid', uid);
+    history.replaceState(null, '', `?${params.toString()}`);
+}
+
+uidField.value = uid;
+if (other) {
+    otherField.value = other;
+    setupEl.style.display = 'none';
+} else {
+    setupEl.style.display = 'block';
+}
+
+startBtn.addEventListener('click', () => {
+    const my = uidField.value.trim();
+    const oth = otherField.value.trim();
+    if (!my || !oth) return;
+    params.set('uid', my);
+    params.set('other', oth);
+    const ids = [my, oth].sort();
+    params.set('room', `${ids[0]}_${ids[1]}`);
+    location.search = '?' + params.toString();
+});
+
 let room = params.get('room');
-
-const uid = params.get('uid');
-const other = params.get('other');
-
 if (!room) {
     if (uid && other) {
         const ids = [uid, other].sort();
         room = `${ids[0]}_${ids[1]}`;
     } else {
-        room = Math.random().toString(36).slice(2, 8);
+        room = Math.random().toString(36).slice(2,8);
     }
     params.set('room', room);
     history.replaceState(null, '', `?${params.toString()}`);
 }
+
 const queryParts = [`room=${encodeURIComponent(room)}`];
 if (uid) queryParts.push(`uid=${encodeURIComponent(uid)}`);
 if (other) queryParts.push(`other=${encodeURIComponent(other)}`);


### PR DESCRIPTION
## Summary
- enable players to enter their own ID and their opponent's ID
- generate persistent player ID using localStorage
- compute room from IDs and connect via WebSocket
- update index.html with small setup form

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6855646326148325a9c32bc4c6e22bee