### PR TITLE
Auto-match players in Discord

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -19,6 +19,7 @@ const wsProto = location.protocol === 'https:' ? 'wss' : 'ws';
 const params = new URLSearchParams(location.search);
 let uid = params.get('uid');
 let other = params.get('other');
+const channelId = params.get('channel_id');
 
 if (!uid) {
     uid = localStorage.getItem('komiId') || Math.random().toString(36).slice(2,8);
@@ -28,7 +29,9 @@ if (!uid) {
 }
 
 uidField.value = uid;
-if (other) {
+if (channelId) {
+    setupEl.style.display = 'none';
+} else if (other) {
     otherField.value = other;
     setupEl.style.display = 'none';
 } else {
@@ -46,7 +49,7 @@ startBtn.addEventListener('click', () => {
     location.search = '?' + params.toString();
 });
 
-let room = params.get('room');
+let room = channelId ? `channel_${channelId}` : params.get('room');
 if (!room) {
     if (uid && other) {
         const ids = [uid, other].sort();
@@ -61,6 +64,7 @@ if (!room) {
 const queryParts = [`room=${encodeURIComponent(room)}`];
 if (uid) queryParts.push(`uid=${encodeURIComponent(uid)}`);
 if (other) queryParts.push(`other=${encodeURIComponent(other)}`);
+if (channelId) queryParts.push(`channel_id=${encodeURIComponent(channelId)}`);
 const ws = new WebSocket(`${wsProto}://${location.host}?${queryParts.join('&')}`);
 
 const turnEl = document.getElementById('turn');

--- a/server.js
+++ b/server.js
@@ -121,7 +121,8 @@ function broadcast(session) {
 
 wss.on('connection', (ws, req) => {
   const url = new URL(req.url, `http://${req.headers.host}`);
-  let room = url.searchParams.get('room');
+  const channelId = url.searchParams.get('channel_id');
+  let room = channelId ? `channel_${channelId}` : url.searchParams.get('room');
   const uid = url.searchParams.get('uid');
   const other = url.searchParams.get('other');
 


### PR DESCRIPTION
## Summary
- auto-hide manual setup when launched in Discord
- use `channel_id` from Discord to pick a match room
- support passing the detected `channel_id` through the websocket URL

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6855fadecd348325982feeb012761b9d